### PR TITLE
Trim version string before comparing in tree-sitter-langs-install-grammar

### DIFF
--- a/tree-sitter-langs-build.el
+++ b/tree-sitter-langs-build.el
@@ -396,7 +396,7 @@ non-nil."
                               (let ((coding-system-for-read 'utf-8))
                                 (insert-file-contents
                                  tree-sitter-langs--bundle-version-file)
-                                (buffer-string))))))
+                                (string-trim (buffer-string)))))))
     (cl-block nil
       (if (string= version current-version)
           (if skip-if-installed


### PR DESCRIPTION
I ran into this issue when manually building the language grammars for Apple Silicon. As I built the language grammar manually, I had to create my own BUNDLE-VERSION file so that `tree-sitter-langs-install-grammar` would not override my build. 

But as BUNDLE-VERSION was manually created, it was terminated with a `\n`. This causes the version comparison to fail because "v0.10.0" != "v0.10.0\n". This fix trims the version string before comparing.