### PR TITLE
Add support for chess Portable Game Notation (PGN)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -151,3 +151,8 @@
 	update = none
     ignore = dirty
     branch = master
+[submodule "repos/pgn"]
+	path = repos/pgn
+	url = https://github.com/rolandwalker/tree-sitter-pgn.git
+	ignore = dirty
+	branch = master

--- a/queries/pgn/highlights.scm
+++ b/queries/pgn/highlights.scm
@@ -1,0 +1,22 @@
+[
+ (annotation)
+ (inline_comment)
+ (rest_of_line_comment)
+ (old_style_twic_section_comment)
+] @comment
+
+(tagpair_delimiter_open) @punctuation.bracket
+(tagpair_delimiter_close) @punctuation.bracket
+(tagpair_key) @type
+(tagpair tagpair_value_delimiter: (double_quote) @string)
+(tagpair_value_contents) @string
+
+(movetext (move_number) @function)
+(movetext (san_move) @function)
+
+(variation_delimiter_open) @operator
+(variation_delimiter_close) @operator
+(variation_movetext variation_san_move: (san_move) @operator)
+(variation_movetext variation_move_number: (move_number) @operator)
+
+(result_code) @property

--- a/tree-sitter-langs.el
+++ b/tree-sitter-langs.el
@@ -104,6 +104,7 @@ See `tree-sitter-langs-repos'."
                 (ocaml-mode      . ocaml)
                 (php-mode        . php)
                 (python-mode     . python)
+                (pygn-mode       . pgn)
                 (rjsx-mode       . javascript)
                 (ruby-mode       . ruby)
                 (rust-mode       . rust)


### PR DESCRIPTION
Not a programming language!  But it works just the same.

The intention is for [pygn-mode](https://github.com/dwcoates/pygn-mode) to depend on emacs-tree-sitter.

cc @dwcoates

Edit: direct link to the PGN grammar: https://github.com/rolandwalker/tree-sitter-pgn