### PR TITLE
Add HCL support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -156,3 +156,6 @@
 	url = https://github.com/rolandwalker/tree-sitter-pgn.git
 	ignore = dirty
 	branch = master
+[submodule "repos/hcl"]
+	path = repos/hcl
+	url = https://github.com/mitchellh/tree-sitter-hcl.git

--- a/queries/hcl/highlights.scm
+++ b/queries/hcl/highlights.scm
@@ -1,0 +1,36 @@
+[
+  "for"
+] @keyword
+
+(attribute (identifier) @property)
+(object_elem (identifier) @property)
+
+(block (identifier) @type)
+(one_line_block (identifier) @type)
+
+(function_call (identifier) @function)
+
+[
+  (string_literal)
+  (quoted_template)
+  (heredoc)
+] @string
+
+(numeric_literal) @number
+
+[
+  (true)
+  (false)
+  (null)
+] @constant.builtin
+
+(comment) @comment
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+]  @punctuation.bracket

--- a/tree-sitter-langs.el
+++ b/tree-sitter-langs.el
@@ -98,6 +98,7 @@ See `tree-sitter-langs-repos'."
                 (css-mode        . css)
                 (elm-mode        . elm)
                 (go-mode         . go)
+                (hcl-mode        . hcl)
                 (html-mode       . html)
                 (mhtml-mode      . html)
                 (java-mode       . java)


### PR DESCRIPTION
Adding support for HCL highlighting. This can additionally be used by other HCL based config (Terraform, Vault, etc) but currently doesn't have additionally highlighting for missing keywords for those specific products.